### PR TITLE
Arena bytes alloced

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -103,6 +103,7 @@ void arena_free(Arena *a);
 
 #endif // ARENA_H_
 
+#define ARENA_IMPLEMENTATION
 #ifdef ARENA_IMPLEMENTATION
 
 #if ARENA_BACKEND == ARENA_BACKEND_LIBC_MALLOC
@@ -282,7 +283,7 @@ char *arena_sprintf(Arena *a, const char *format, ...)
 size_t arena_bytes(Arena *a) {
 	size_t bytes_total = 0;
 	for (Region* r = a->begin; r != NULL; r = r->next) {
-		bytes_total += r->count * 8;
+		bytes_total += r->count * sizeof(uintptr_t);
 	}
 	return bytes_total;
 }

--- a/arena.h
+++ b/arena.h
@@ -75,6 +75,7 @@ void *arena_memdup(Arena *a, void *data, size_t size);
 char *arena_sprintf(Arena *a, const char *format, ...);
 #endif // ARENA_NOSTDIO
 
+size_t arena_bytes(Arena *a);
 void arena_reset(Arena *a);
 void arena_free(Arena *a);
 
@@ -277,6 +278,14 @@ char *arena_sprintf(Arena *a, const char *format, ...)
     return result;
 }
 #endif // ARENA_NOSTDIO
+
+size_t arena_bytes(Arena *a) {
+	size_t bytes_total = 0;
+	for (Region* r = a->begin; r != NULL; r = r->next) {
+		bytes_total += r->count * 8;
+	}
+	return bytes_total;
+}
 
 void arena_reset(Arena *a)
 {

--- a/arena.h
+++ b/arena.h
@@ -103,7 +103,6 @@ void arena_free(Arena *a);
 
 #endif // ARENA_H_
 
-#define ARENA_IMPLEMENTATION
 #ifdef ARENA_IMPLEMENTATION
 
 #if ARENA_BACKEND == ARENA_BACKEND_LIBC_MALLOC


### PR DESCRIPTION
**What?** Added `arena_bytes()` function that counts up how many bytes are allocated in the arena
**Why?** I wanted to be able to easily see how much memory was allocated over the course of using the arena.
**How?** Traverse through the regions and tally up all of their counts
**Testing** I totaled up the allocations and made sure the displayed byte count was accurate.

Thank you for making such useful and simple libraries for us all to use!