### PR TITLE
Add transparent hugepage support for x86_64.

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -175,6 +175,12 @@ Region *new_region(size_t capacity)
 void free_region(Region *r)
 {
     size_t size_bytes = sizeof(Region) + sizeof(uintptr_t) * r->capacity;
+#if defined(ARENA_HUGEPAGES)
+    // NOTE: assuming 2MB transparent hugepage size (common on x86_64 systems).
+    size_t hugepage_size = 2 << 20;
+    size_bytes = ARENA_ALIGN_POW2(size_bytes, hugepage_size);
+#endif
+
     int ret = munmap(r, size_bytes);
     ARENA_ASSERT(ret == 0);
 }


### PR DESCRIPTION
Test program and output.
```sh
maria@maria-desktop ~/Work/arena $ gcc -Wall -Wextra test.c && ./a.out 
8193 faults (4095.50 bytes/fault)
maria@maria-desktop ~/Work/arena $ gcc -Wall -Wextra -DARENA_HUGEPAGES test.c && ./a.out 
17 faults (1973790.12 bytes/fault)
```
```c
#define ARENA_IMPLEMENTATION
#define ARENA_BACKEND ARENA_BACKEND_LINUX_MMAP
#include "arena.h"

#include <sys/resource.h>

static int64_t
get_page_fault_count(void)
{
    int64_t result = 0;

    struct rusage resource_usage = {};
    if(getrusage(RUSAGE_SELF, &resource_usage) == 0)
    {
        result = resource_usage.ru_minflt + resource_usage.ru_majflt;
    }

    return result;
}

int main(void)
{
    Arena arena = {};

    int64_t begin_fault_count = get_page_fault_count();

    uint64_t allocation_size = 32 << 20;
    uint8_t *allocation = arena_alloc(&arena, allocation_size);

    for(uint64_t index = 0;
        index < allocation_size;
        ++index)
    {
        allocation[index] = (uint8_t)index;
    }

    arena_free(&arena);

    int64_t end_fault_count = get_page_fault_count();
    int64_t fault_count = end_fault_count - begin_fault_count;
    printf("%ld faults (%.2f bytes/fault)\n", fault_count, (float)allocation_size/(float)fault_count);

    return 0;
}
```