### PR TITLE
Added Basic Clib.json for Clib

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,0 +1,16 @@
+{
+  "name": "arena",
+  "version": "0.1.0",
+  "repo": "tsoding/arena",
+  "description": "Arena Allocator implementation in pure C as an stb-style single-file library.",
+  "keywords": [
+    "C",
+    "Memory Management",
+    "WASM"
+  ],
+  "license": "MIT",
+  "dependencies": {},
+  "src": [
+    "arena.h"
+  ]
+}


### PR DESCRIPTION
Hiya, 

I love this project and would like to have it available in the clib package manager for C. This clib.json file acts like a package.json for those familiar with NPM/Yarn style package managers. I can handle the publishing to the "Catalog" but in order to get clib to read it the repo must have this file. 

If you would like more information on clib checkout https://github.com/clibs/clib.

Thanks,
Phoenix