### PR TITLE
Added format attribute to arena_sprintf

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -376,7 +376,13 @@ char *arena_vsprintf(Arena *a, const char *format, va_list args)
     return result;
 }
 
-char *arena_sprintf(Arena *a, const char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+#define CHECK_PRINTF_FMT(a, b) __attribute__ ((format (printf, a, b)))
+#else
+#define CHECK_PRINTF_FMT(...)
+#endif
+
+CHECK_PRINTF_FMT(2, 3) char *arena_sprintf(Arena *a, const char *format, ...)
 {
     va_list args;
     va_start(args, format);


### PR DESCRIPTION
I noticed that we do not get compiler warnings when we try to compile something like
```C
#include <stdio.h>

#define ARENA_IMPLEMENTATION
#include "arena.h"

int main() {
    Arena a = {0};
    char *test1 = arena_sprintf(&a, "foo", 3, "bar");
    char *test2 = arena_sprintf(&a, "foo %d %s", 3);
    char *test3 = arena_sprintf(&a, "foo %d", "baz");
    printf("%s\n", test1);
    printf("%s\n", test2);
    printf("%s\n", test3);
}
```
At least for gcc and clang this is possible to enable by using an attribute. So I copied the macro `CHECK_PRINTF_FMT` from this old linear algebra project of yours: https://github.com/tsoding/la/blob/master/lag.c
Now we get some warnings for the above code.