### PR TITLE
Change `da` macros to use `.`

### DIFF
--- a/arena.h
+++ b/arena.h
@@ -97,33 +97,33 @@ void arena_trim(Arena *a);
 
 #define arena_da_append(a, da, item)                                                          \
     do {                                                                                      \
-        if ((da)->count >= (da)->capacity) {                                                  \
-            size_t new_capacity = (da)->capacity == 0 ? ARENA_DA_INIT_CAP : (da)->capacity*2; \
-            (da)->items = cast_ptr((da)->items)arena_realloc(                                 \
-                (a), (da)->items,                                                             \
-                (da)->capacity*sizeof(*(da)->items),                                          \
-                new_capacity*sizeof(*(da)->items));                                           \
-            (da)->capacity = new_capacity;                                                    \
+        if ((da).count >= (da).capacity) {                                                    \
+            size_t new_capacity = (da).capacity == 0 ? ARENA_DA_INIT_CAP : (da).capacity*2;   \
+            (da).items = cast_ptr((da).items)arena_realloc(                                   \
+                (a), (da).items,                                                              \
+                (da).capacity*sizeof(*(da).items),                                            \
+                new_capacity*sizeof(*(da).items));                                            \
+            (da).capacity = new_capacity;                                                     \
         }                                                                                     \
                                                                                               \
-        (da)->items[(da)->count++] = (item);                                                  \
+        (da).items[(da).count++] = (item);                                                    \
     } while (0)
 
 // Append several items to a dynamic array
 #define arena_da_append_many(a, da, new_items, new_items_count)                                       \
     do {                                                                                              \
-        if ((da)->count + (new_items_count) > (da)->capacity) {                                       \
-            size_t new_capacity = (da)->capacity;                                                     \
+        if ((da).count + (new_items_count) > (da).capacity) {                                         \
+            size_t new_capacity = (da).capacity;                                                      \
             if (new_capacity == 0) new_capacity = ARENA_DA_INIT_CAP;                                  \
-            while ((da)->count + (new_items_count) > new_capacity) new_capacity *= 2;                 \
-            (da)->items = cast_ptr((da)->items)arena_realloc(                                         \
-                (a), (da)->items,                                                                     \
-                (da)->capacity*sizeof(*(da)->items),                                                  \
-                new_capacity*sizeof(*(da)->items));                                                   \
-            (da)->capacity = new_capacity;                                                            \
+            while ((da).count + (new_items_count) > new_capacity) new_capacity *= 2;                  \
+            (da).items = cast_ptr((da).items)arena_realloc(                                           \
+                (a), (da).items,                                                                      \
+                (da).capacity*sizeof(*(da).items),                                                    \
+                new_capacity*sizeof(*(da).items));                                                    \
+            (da).capacity = new_capacity;                                                             \
         }                                                                                             \
-        arena_memcpy((da)->items + (da)->count, (new_items), (new_items_count)*sizeof(*(da)->items)); \
-        (da)->count += (new_items_count);                                                             \
+        arena_memcpy((da).items + (da).count, (new_items), (new_items_count)*sizeof(*(da).items));    \
+        (da).count += (new_items_count);                                                              \
     } while (0)
 
 // Append a sized buffer to a string builder


### PR DESCRIPTION
Changed `da` macros to use `.` instead of `->`.
The `da` macros should be able to be used on values and pointers (which they currently are) using:
`arena_da_append(a, da, item)` where da is a pointer, which expands to code using `(da)->capacity` and
`arena_da_append(a, &da, item)` where da is a value, which expands to code using `(&da)->capacity`
`(da)->capacity` is good
`(&da)->capacity` is not good because it is usually optimised to `da.capacity`, but this is not guaranteed.
But, in this PR, the calling code would use:
`arena_da_append(a, *da, item)` where da is a pointer, which expands to code using `(*da).capacity` and
`arena_da_append(a, da, item)` where da is a value, which expands to code using `(da).capacity`
`(*da).capacity` is good because it is _equivalent_ to `da->capacity`
`(da).capacity` is good